### PR TITLE
refactor: Reorganize U4AOS1 content under 8 Key Skill headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,12 +131,14 @@
                     <p class="mb-6 text-slate-600">This area of study focuses on how the Australian Constitution establishes law-making powers and acts as a check on parliament, the significance of the High Court, and the roles of parliament and courts in law-making. You will explore their relationship and the factors affecting their ability to make law.</p>
 
                     <div class="mb-6 flex flex-wrap justify-center gap-2">
-                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-parliament-constitution">Parliament & Constitution</button>
-                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-factors-parliament">Factors Affecting Parliament</button>
-                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-constitution-checks">Constitution as a Check</button>
-                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-courts-lawmaking">Courts in Law-Making</button>
-                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-factors-courts">Factors Affecting Courts</button>
-                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-courts-parliament-relationship">Courts & Parliament Relationship</button>
+                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-ks1">1. Roles of Crown & Parliament</button>
+                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-ks2">2. Division of Powers</button>
+                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-ks3">3. Significance of s109</button>
+                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-ks4">4. Constitution as a Check</button>
+                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-ks5">5. High Court Cases & Powers</button>
+                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-ks6">6. Courts' Role in Law-Making</button>
+                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-ks7">7. Factors Affecting Courts</button>
+                        <button class="u4aos1-content-toggle py-2 px-3 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 text-sm" data-target="u4aos1-ks8">8. Court & Parliament Relationship</button>
                         <button class="u4aos1-content-toggle py-2 px-3 bg-teal-100 text-teal-700 rounded hover:bg-teal-200 text-sm" data-target="u4aos1-glossary">Interactive Glossary</button>
                         <button class="u4aos1-content-toggle py-2 px-3 bg-teal-100 text-teal-700 rounded hover:bg-teal-200 text-sm" data-target="u4aos1-interactive-diagrams">Interactive Diagrams</button>
                         <button class="u4aos1-content-toggle py-2 px-3 bg-teal-100 text-teal-700 rounded hover:bg-teal-200 text-sm" data-target="u4aos1-case-explorer">Case Explorer</button>
@@ -149,138 +151,286 @@
                     </div>
 
                     <div id="u4aos1-accordion-container" class="space-y-3">
-                        <div id="u4aos1-parliament-constitution" class="u4aos1-content hidden">
+                        <div id="u4aos1-ks1" class="u4aos1-content hidden">
                             <div class="border border-slate-300 rounded-lg">
                                 <button class="accordion-toggle w-full text-left p-4 bg-indigo-50 hover:bg-indigo-100 rounded-t-lg">
                                     <div class="flex justify-between items-center">
-                                        <h4 class="text-lg font-medium text-indigo-700">Parliament and the Australian Constitution</h4>
+                                        <h4 class="text-lg font-medium text-indigo-700">Roles of the Crown and the Houses of Parliament (Victorian and Commonwealth)</h4>
                                         <span class="arrow-icon text-indigo-700 text-xl transform transition-transform duration-300">▼</span>
                                     </div>
                                 </button>
                                 <div class="accordion-content p-4 border-t border-slate-200">
-                                    <p class="mb-3 text-slate-600">This section explores the roles of the Crown and Houses of Parliament in law-making, the division of law-making powers, the significance of s109, and the impact of High Court cases [cite: 625-630].</p>
-                                    <h5 class="font-semibold text-indigo-600 mt-2 mb-1">Roles of Crown & Houses of Parliament (Vic & Cth)</h5>
-                                    <ul class="list-disc list-inside ml-4 text-slate-600 text-sm space-y-1">
-                                        <li>Commonwealth Parliament: King (rep. by Governor-General), Senate (Upper House), House of Representatives (Lower House).</li>
-                                        <li>Victorian Parliament: King (rep. by Governor), Legislative Council (Upper House), Legislative Assembly (Lower House).</li>
-                                        <li>Lower Houses (House of Reps/Legislative Assembly): Initiate laws (especially money bills), form government, represent people, scrutinise government.</li>
-                                        <li>Upper Houses (Senate/Legislative Council): Act as house of review, scrutinise bills, represent states/regions, can initiate non-money bills [cite: 405-406].</li>
-                                        <li>The Crown (Governor-General/Governor): Grants Royal Assent to bills for them to become law.</li>
-                                    </ul>
-                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Division of Law-Making Powers</h5>
-                                     <ul class="list-disc list-inside ml-4 text-slate-600 text-sm space-y-1">
-                                        <li>Exclusive Powers: Exercised only by Commonwealth Parliament (e.g., defence, currency, customs).</li>
-                                        <li>Concurrent Powers: Shared by Commonwealth and State Parliaments (e.g., taxation, marriage, trade).</li>
-                                        <li>Residual Powers: Powers remaining with State Parliaments, not listed in Constitution (e.g., criminal law, education, public transport).</li>
-                                    </ul>
-                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Significance of Section 109</h5>
-                                    <p class="text-slate-600 text-sm">If a state law is inconsistent with a Commonwealth law in an area of concurrent power, the Commonwealth law prevails, and the state law is invalid to the extent of the inconsistency. This requires a court challenge.</p>
-                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">High Court Cases Impacting Law-Making Powers</h5>
-                                    <p class="text-slate-600 text-sm">Cases like <em>R v Brislan</em> (broadened Cth power over communications [cite: 93-95, 423]) and <em>Commonwealth v Tasmania (Tasmanian Dams Case)</em> (Cth can legislate on matters of international treaties, impacting state residual powers [cite: 96-99, 424]) have significantly affected the division of powers.</p>
-                                    <p class="mt-2 text-xs text-slate-400">Refer to 'Interactive Diagrams' and 'Case Explorer' for more.</p>
-                                </div>
-                            </div>
-                        </div>
+                                    <h5 class="font-semibold text-indigo-600 mt-2 mb-1">Purpose of Parliament</h5>
+                                    <p class="text-sm text-slate-600 mb-2">Parliament is the supreme law-making body within its jurisdiction. It consists of the Crown's representative and two houses.</p>
 
-                        <div id="u4aos1-factors-parliament" class="u4aos1-content hidden">
-                           <div class="border border-slate-300 rounded-lg">
-                                <button class="accordion-toggle w-full text-left p-4 bg-indigo-50 hover:bg-indigo-100 rounded-t-lg">
-                                    <div class="flex justify-between items-center">
-                                        <h4 class="text-lg font-medium text-indigo-700">Factors Affecting Parliament's Ability to Make Law</h4>
-                                        <span class="arrow-icon text-indigo-700 text-xl transform transition-transform duration-300">▼</span>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Commonwealth Parliament</h5>
+                                    <p class="text-sm text-slate-600 mb-2">Consists of the King (represented by the Governor-General), the Senate (upper house), and the House of Representatives (lower house).</p>
+                                    <div class="ml-4">
+                                        <h6 class="font-semibold text-indigo-500 mt-2 mb-1">House of Representatives (Lower House)</h6>
+                                        <p class="text-xs text-slate-500 mb-1 italic">Sometimes called the 'people's house' or the 'house of government'. It is comprised of 151 members representing electorates across Australia.</p>
+                                        <p class="text-sm text-slate-600 mb-1"><strong>Key Roles:</strong></p>
+                                        <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                            <li>Initiate and make laws. Most new laws are initiated here, usually by the government.</li>
+                                            <li>Determine the government. The party with the majority of members forms government.</li>
+                                            <li>Represent the people. Members are elected to represent their electorates and should reflect their views.</li>
+                                            <li>Scrutinise government administration. Includes questioning ministers.</li>
+                                            <li>Act as a house of review. Reviews bills initiated in the Senate.</li>
+                                            <li>Control government expenditure. Only the lower house can initiate money bills (taxation and appropriation).</li>
+                                        </ul>
+                                        <h6 class="font-semibold text-indigo-500 mt-2 mb-1">Senate (Upper House)</h6>
+                                        <p class="text-xs text-slate-500 mb-1 italic">Often referred to as the 'states' house' or the house of review. It has 76 elected members (12 from each state, 2 from each territory), elected for six years. It is designed for equal representation of states.</p>
+                                        <p class="text-sm text-slate-600 mb-1"><strong>Key Roles:</strong></p>
+                                        <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                            <li>Review laws from the House of Representatives. This is its primary role. It can amend or reject bills.</li>
+                                            <li>Allow for equal representation of the states.</li>
+                                            <li>Scrutinise bills and government administration. Often done through committees.</li>
+                                            <li>Initiate and pass bills (except money bills).</li>
+                                        </ul>
                                     </div>
-                                </button>
-                                <div class="accordion-content p-4 border-t border-slate-200">
-                                    <p class="mb-3 text-slate-600">Parliament's effectiveness in law-making is influenced by several factors.</p>
-                                    <ul class="list-disc list-inside ml-4 text-slate-600 text-sm space-y-1">
-                                        <li><strong>Bicameral Structure:</strong>
-                                            A 'hostile upper house' (government lacks majority) can increase scrutiny but slow law-making. A 'rubber stamp' (government controls both houses) can mean less scrutiny but faster law-making [cite: 371, 520-521].
-                                        </li>
-                                        <li><strong>International Pressures:</strong> Treaties and international organisations (e.g., UN) can pressure parliament to make laws complying with international standards [cite: 254, 373-374, 452]. Failure to comply can lead to criticism.</li>
-                                        <li><strong>Representative Nature of Parliament (Representative Government):</strong> Parliament should reflect community views (s7 & s24 of Constitution). Regular elections, political parties, and independents influence this.</li>
+
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Victorian Parliament</h5>
+                                    <p class="text-sm text-slate-600 mb-2">Consists of the King (represented by the Governor), the Legislative Council (upper house), and the Legislative Assembly (lower house).</p>
+                                    <div class="ml-4">
+                                        <h6 class="font-semibold text-indigo-500 mt-2 mb-1">Legislative Assembly (Lower House)</h6>
+                                        <p class="text-xs text-slate-500 mb-1 italic">Comprised of 88 members representing electoral districts. The party with the majority forms the Victorian government.</p>
+                                        <p class="text-sm text-slate-600 mb-1"><strong>Key Roles:</strong></p>
+                                        <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                            <li>Initiate and pass bills. Most new legislation starts here.</li>
+                                            <li>Form government.</li>
+                                            <li>Represent the people. Members represent the interests of their districts.</li>
+                                            <li>Act as a house of review. Reviews bills from the Legislative Council.</li>
+                                            <li>Control government expenditure. Initiates financial spending legislation (the Budget).</li>
+                                            <li>Scrutinise government administration.</li>
+                                        </ul>
+                                        <h6 class="font-semibold text-indigo-500 mt-2 mb-1">Legislative Council (Upper House)</h6>
+                                        <p class="text-xs text-slate-500 mb-1 italic">Primarily acts as a 'house of review'. Has 40 elected members representing eight regions.</p>
+                                        <p class="text-sm text-slate-600 mb-1"><strong>Key Roles:</strong></p>
+                                        <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                            <li>Act as a house of review. Reviews bills from the Legislative Assembly. It can amend or reject bills (except appropriation/money bills).</li>
+                                            <li>Scrutinise government administration.</li>
+                                            <li>Initiate and pass bills. Bills can start here, but most start in the Assembly.</li>
+                                        </ul>
+                                    </div>
+
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">The Crown (Governor-General Federally, Governor in Victoria)</h5>
+                                    <p class="text-sm text-slate-600 mb-2">The British monarch is part of the system, represented by the Governor-General and state Governors. They act on the advice of the government.</p>
+                                    <p class="text-sm text-slate-600 mb-1"><strong>Key Roles in Law-Making:</strong></p>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li>Grant royal assent. This is the formal signing and approval of a bill after it has passed both houses, making it an Act of Parliament. It is required for a bill to become law.</li>
+                                        <li>Withholding royal assent. The power to refuse approval, which is rare.</li>
+                                        <li>Appointing the Executive Council. This council (leader of government, ministers) advises the Crown's representative and approves secondary legislation.</li>
                                     </ul>
                                 </div>
                             </div>
                         </div>
-
-                        <div id="u4aos1-constitution-checks" class="u4aos1-content hidden">
+                        <div id="u4aos1-ks2" class="u4aos1-content hidden">
                             <div class="border border-slate-300 rounded-lg">
                                 <button class="accordion-toggle w-full text-left p-4 bg-indigo-50 hover:bg-indigo-100 rounded-t-lg">
                                     <div class="flex justify-between items-center">
-                                        <h4 class="text-lg font-medium text-indigo-700">The Constitution as a Check on Parliament</h4>
+                                        <h4 class="text-lg font-medium text-indigo-700">The Division of Law-making Powers</h4>
                                         <span class="arrow-icon text-indigo-700 text-xl transform transition-transform duration-300">▼</span>
                                     </div>
                                 </button>
                                 <div class="accordion-content p-4 border-t border-slate-200">
-                                    <p class="mb-3 text-slate-600">The Australian Constitution acts as a check on parliamentary law-making power through several mechanisms [cite: 632-633, 427, 544].</p>
-                                     <ul class="list-disc list-inside ml-4 text-slate-600 text-sm space-y-1">
-                                        <li><strong>Role of the High Court in Protecting Representative Government:</strong> The High Court interprets ss 7 and 24 of the Constitution to protect representative government, including an implied right to freedom of political communication (<em>ACTV case</em>) [cite: 62, 594-595] and defining voting rights (<em>Roach v Electoral Commissioner</em> [cite: 247, 317-318, 597]).</li>
-                                        <li><strong>Separation of Powers:</strong> Divides power between legislative (parliament), executive (government [cite: 64, 234, 531-533]), and judicial (courts [cite: 65, 235, 534-535]) branches to prevent abuse. The independent judiciary can declare laws ultra vires (<em>Australian Communist Party v Commonwealth</em>). Overlap exists between legislative and executive.</li>
-                                        <li><strong>Express Protection of Rights:</strong> Five rights are explicitly stated (e.g., s51(xxxi) acquisition of property on just terms, s116 freedom of religion). These are entrenched and can be enforced by the High Court, but are limited in number and scope.</li>
-                                        <li><strong>Bicameral Structure:</strong> (Covered under 'Factors Affecting Parliament') The need for bills to pass both houses acts as a check.</li>
-                                        <li><strong>Requirement for a Double Majority in a Referendum (s128):</strong> Changing the Constitution requires approval by a national majority of voters and a majority of voters in a majority of states. This makes constitutional change difficult.</li>
+                                    <p class="text-sm text-slate-600 mb-2">The Australian Constitution divides law-making powers between the Commonwealth and state parliaments. This division aims to distribute responsibilities and safeguard against abuse of power.</p>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Exclusive Powers</h5>
+                                    <p class="text-sm text-slate-600 mb-2">Powers that can only be exercised by the Commonwealth Parliament. State parliaments cannot legislate in these areas. These are granted by sections 51 and 52 of the Constitution, or made exclusive by other sections or by their nature.</p>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li>Examples: Currency, defence, customs and border protection, foreign affairs, overseas trade.</li>
                                     </ul>
-                                    <p class="mt-2 text-xs text-slate-400">Refer to 'Interactive Diagrams' for a visual representation.</p>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Concurrent Powers</h5>
+                                    <p class="text-sm text-slate-600 mb-2">Powers shared by both the Commonwealth and state parliaments. Both can make laws in these areas. These are listed in section 51 of the Constitution.</p>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li>Examples: Taxation, marriage and divorce, trade, postal/telegraphic/telephonic services. Conflicts between state and Commonwealth laws in these areas are resolved by section 109.</li>
+                                    </ul>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Residual Powers</h5>
+                                    <p class="text-sm text-slate-600 mb-2">Powers that were left with the states at Federation and are not listed in the Constitution. The Commonwealth Parliament has no authority to make laws in these areas.</p>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li>Examples: Criminal law, education, public transport, medical procedures, road laws, agriculture, police, prisons. Residual powers mean laws can differ between states.</li>
+                                    </ul>
                                 </div>
                             </div>
                         </div>
-
-                        <div id="u4aos1-courts-lawmaking" class="u4aos1-content hidden">
+                        <div id="u4aos1-ks3" class="u4aos1-content hidden">
                             <div class="border border-slate-300 rounded-lg">
                                 <button class="accordion-toggle w-full text-left p-4 bg-indigo-50 hover:bg-indigo-100 rounded-t-lg">
                                     <div class="flex justify-between items-center">
-                                        <h4 class="text-lg font-medium text-indigo-700">Victorian Courts and High Court in Law-Making</h4>
+                                        <h4 class="text-lg font-medium text-indigo-700">The Significance of Section 109 of the Australian Constitution</h4>
                                         <span class="arrow-icon text-indigo-700 text-xl transform transition-transform duration-300">▼</span>
                                     </div>
                                 </button>
                                 <div class="accordion-content p-4 border-t border-slate-200">
-                                    <p class="mb-3 text-slate-600">Courts make law through statutory interpretation and the doctrine of precedent [cite: 634-635, 392].</p>
-                                    <h5 class="font-semibold text-indigo-600 mt-2 mb-1">Statutory Interpretation</h5>
-                                    <p class="text-slate-600 text-sm">Courts give meaning to words in legislation when applying it to a case. Reasons include clarifying ambiguity (<em>Deing v Tarola</em>), reflecting changing word nature (<em>A-G v Kevin and Jennifer</em>), and applying to unforeseen circumstances. Effects include creating precedent, broadening/narrowing statutes, and prompting legislative change.</p>
+                                    <h5 class="font-semibold text-indigo-600 mt-2 mb-1">Purpose of Section 109</h5>
+                                    <p class="text-sm text-slate-600 mb-2">Section 109 resolves conflicts between state and Commonwealth laws in areas of concurrent power.</p>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Mechanism</h5>
+                                    <p class="text-sm text-slate-600 mb-2">If a state law is inconsistent with a Commonwealth law, the Commonwealth law prevails, and the state law is invalid <strong>to the extent of the inconsistency</strong>. Only the inconsistent sections of the state law are invalid; other sections remain in force.</p>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Significance</h5>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li>It provides a way to resolve inconsistencies between state and Commonwealth legislation.</li>
+                                        <li>It <strong>restricts the law-making powers of the states</strong> in areas where the Commonwealth has also legislated. States recognise this constraint when making laws in concurrent areas.</li>
+                                        <li>It provides a common approach for resolving conflicts.</li>
+                                    </ul>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Limitations</h5>
+                                    <p class="text-sm text-slate-600 mb-2">Section 109 does not automatically invalidate state laws; the law needs to be <strong>challenged in court</strong> for the inconsistency to be determined and the state law declared invalid. If the conflicting Commonwealth law is changed or removed, the invalid part of the state law may become valid again.</p>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Example Case</h5>
+                                    <p class="text-sm text-slate-600 mb-2"><em>McBain v Victoria (2000)</em> is a significant case where the High Court used section 109 to invalidate a section of the Victorian <em>Infertility Treatment Act 1995</em> that was inconsistent with the Commonwealth <em>Sex Discrimination Act 1984</em>, allowing single women access to IVF treatment.</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="u4aos1-ks4" class="u4aos1-content hidden">
+                            <div class="border border-slate-300 rounded-lg">
+                                <button class="accordion-toggle w-full text-left p-4 bg-indigo-50 hover:bg-indigo-100 rounded-t-lg">
+                                    <div class="flex justify-between items-center">
+                                        <h4 class="text-lg font-medium text-indigo-700">The Ways the Australian Constitution Acts as a Check on Parliament in Law-making</h4>
+                                        <span class="arrow-icon text-indigo-700 text-xl transform transition-transform duration-300">▼</span>
+                                    </div>
+                                </button>
+                                <div class="accordion-content p-4 border-t border-slate-200">
+                                    <p class="text-sm text-slate-600 mb-2">The Constitution establishes structures and principles that limit Parliament's law-making power to prevent abuse.</p>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">The Bicameral Structure</h5>
+                                    <p class="text-sm text-slate-600 mb-1">The requirement for two houses (House of Representatives/Senate federally, Legislative Assembly/Legislative Council in Victoria).</p>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li><strong>How it Checks:</strong> The upper house acts as a <strong>house of review</strong> for bills passed by the lower house. This allows for scrutiny, debate, and potential amendments, improving the quality of laws. This check is particularly effective with a <strong>'hostile upper house'</strong>, where the government doesn't have a majority and needs crossbench support, increasing scrutiny. A deadlock between houses can also limit government legislative power.</li>
+                                        <li><strong>Limitations:</strong> If the government holds a <strong>majority in the upper house ('rubber stamp' upper house)</strong>, bills may pass with little scrutiny or debate. A hostile upper house can also cause delays and negotiations based on minority interests.</li>
+                                    </ul>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">The Separation of Powers</h5>
+                                    <p class="text-sm text-slate-600 mb-1">The Constitution divides powers into legislative (parliament makes laws), executive (administers laws), and judicial (courts apply laws and resolve disputes).</p>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li><strong>How it Checks:</strong> Aims to prevent the abuse of power by ensuring no single body holds all three powers. The <strong>independent judiciary (High Court)</strong> can act as a check by interpreting laws and the Constitution and declaring laws made beyond Parliament's power (ultra vires) invalid. The legislature can also scrutinise the executive through processes like Question Time.</li>
+                                        <li><strong>Limitations:</strong> There is an <strong>overlap between the legislative and executive</strong> branches in practice, as ministers are part of both Cabinet (executive) and Parliament (legislature). Judges are appointed by the executive, potentially influencing the judiciary's composition. The separation is constitutionally entrenched only at the federal level, although the principle is generally followed at the state level.</li>
+                                    </ul>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Express Protection of Rights</h5>
+                                    <p class="text-sm text-slate-600 mb-1">The Constitution explicitly protects five specific rights that are entrenched and can only be changed by a referendum (section 128).</p>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li><strong>How it Checks:</strong> These entrenched rights directly <strong>limit Parliament's law-making power</strong>, preventing them from making laws that infringe upon these specific rights. They are legally enforceable; individuals can challenge laws potentially breaching these rights in the High Court, which can declare them invalid.</li>
+                                        <li><strong>Limitations:</strong> Only a <strong>limited number of rights</strong> are expressly protected (five). Some rights have <strong>limited scope</strong> and may not apply to state laws or all situations (e.g., s80 jury trial only for Commonwealth indictable offences). Changing or adding rights via referendum is very difficult and costly. Enforcing these rights through the High Court can be costly and time-consuming, requiring standing.</li>
+                                    </ul>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Role of the High Court in Protecting Representative Government</h5>
+                                    <p class="text-sm text-slate-600 mb-1">Sections 7 and 24 require Parliament to be 'directly chosen by the people', establishing representative government.</p>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li><strong>How it Checks:</strong> The High Court interprets sections 7 and 24 and can declare laws invalid if they infringe upon this principle. This includes recognizing implied rights necessary for representative government, such as the <strong>implied freedom of political communication</strong>.</li>
+                                        <li><strong>Example:</strong> <em>Roach v Electoral Commissioner (2007)</em> is a key case where the High Court held that a complete ban on prisoners voting was unconstitutional as it infringed upon the principle of representative government under sections 7 and 24.</li>
+                                        <li><strong>Limitations:</strong> The High Court can only act when a case is brought before it. Litigation is costly and time-consuming and requires standing. Judges are not elected, which some view as undemocratic.</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="u4aos1-ks5" class="u4aos1-content hidden">
+                            <div class="border border-slate-300 rounded-lg">
+                                <button class="accordion-toggle w-full text-left p-4 bg-indigo-50 hover:bg-indigo-100 rounded-t-lg">
+                                    <div class="flex justify-between items-center">
+                                        <h4 class="text-lg font-medium text-indigo-700">The Significance of High Court Cases in Interpreting Sections 7 and 24 of the Australian Constitution and the Division of Law-making Powers</h4>
+                                        <span class="arrow-icon text-indigo-700 text-xl transform transition-transform duration-300">▼</span>
+                                    </div>
+                                </button>
+                                <div class="accordion-content p-4 border-t border-slate-200">
+                                    <p class="text-sm text-slate-600 mb-2">The High Court interprets the Constitution and its decisions can impact the division of law-making powers between the Commonwealth and states.</p>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">R v Brislan; Ex parte Williams (1935)</h5>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li><strong>Issue:</strong> Interpretation of 'other like services' in section 51(v) (postal, telegraphic, telephonic powers).</li>
+                                        <li><strong>Decision:</strong> The High Court interpreted 'other like services' to include radio broadcasting.</li>
+                                        <li><strong>Impact/Significance:</strong> This decision broadened the Commonwealth's law-making power and resulted in a shift of power to the Commonwealth in the area of communications. This interpretation has influenced the Commonwealth's assumption of power to legislate over new technologies like television and potentially the internet.</li>
+                                        <li><strong>Limitations:</strong> The decision doesn't automatically extend to <em>all</em> new technologies without further cases.</li>
+                                    </ul>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Commonwealth v Tasmania (Tasmanian Dam case) (1983)</h5>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li><strong>Issue:</strong> Interpretation of the 'external affairs' power in section 51(xxix). Could the Commonwealth use this power to legislate on a residual matter (dam construction) to implement a treaty obligation (World Heritage Convention)?.</li>
+                                        <li><strong>Decision:</strong> The High Court held that the external affairs power allows the Commonwealth to legislate to fulfil genuine international treaty obligations, even if the subject matter is typically a state residual power. This meant the Commonwealth law prevailed over the inconsistent state law under section 109.</li>
+                                        <li><strong>Impact/Significance:</strong> This resulted in a significant <strong>shift in the division of law-making powers from the states to the Commonwealth</strong>. The Commonwealth gained the ability to legislate on areas covered by international treaties, potentially extending to human rights.</li>
+                                        <li><strong>Limitations:</strong> The Commonwealth cannot legislate beyond the scope of the treaty, the treaty must be genuine, and the power doesn't extinguish the state's residual power entirely.</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="u4aos1-ks6" class="u4aos1-content hidden">
+                            <div class="border border-slate-300 rounded-lg">
+                                <button class="accordion-toggle w-full text-left p-4 bg-indigo-50 hover:bg-indigo-100 rounded-t-lg">
+                                    <div class="flex justify-between items-center">
+                                        <h4 class="text-lg font-medium text-indigo-700">The Role of the Victorian Courts and the High Court in Law-making</h4>
+                                        <span class="arrow-icon text-indigo-700 text-xl transform transition-transform duration-300">▼</span>
+                                    </div>
+                                </button>
+                                <div class="accordion-content p-4 border-t border-slate-200">
+                                    <p class="text-sm text-slate-600 mb-2">Courts make law through the <strong>doctrine of precedent</strong> and <strong>statutory interpretation</strong> when determining cases.</p>
                                     <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Doctrine of Precedent</h5>
-                                    <p class="text-slate-600 text-sm">Judges follow reasons for decisions (ratio decidendi [cite: 255, 437, 850-851]) of superior courts in the same hierarchy for similar cases (stare decisis).
-                                    Features include: binding precedent (must follow), persuasive precedent (can guide, e.g., obiter dictum, decisions from other hierarchies).
-                                    Ways of developing/avoiding: reversing (same case on appeal), overruling (different later case by superior court), distinguishing (material facts different), disapproving (lower court disagrees but follows).</p>
-                                    <p class="mt-2 text-xs text-slate-400">Refer to 'Case Explorer' for examples.</p>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div id="u4aos1-factors-courts" class="u4aos1-content hidden">
-                            <div class="border border-slate-300 rounded-lg">
-                                <button class="accordion-toggle w-full text-left p-4 bg-indigo-50 hover:bg-indigo-100 rounded-t-lg">
-                                    <div class="flex justify-between items-center">
-                                        <h4 class="text-lg font-medium text-indigo-700">Factors Affecting Courts' Ability to Make Law</h4>
-                                        <span class="arrow-icon text-indigo-700 text-xl transform transition-transform duration-300">▼</span>
-                                    </div>
-                                </button>
-                                <div class="accordion-content p-4 border-t border-slate-200">
-                                    <p class="mb-3 text-slate-600">Several factors can influence or limit the courts' law-making role.</p>
-                                    <ul class="list-disc list-inside ml-4 text-slate-600 text-sm space-y-1">
-                                        <li><strong>Doctrine of Precedent:</strong> While providing consistency, it also restricts judges as they are bound by higher court decisions and must wait for a relevant case.</li>
-                                        <li><strong>Judicial Conservatism and Judicial Activism:</strong> Conservatism is a reluctance to make significant new law, deferring to parliament. Activism is a willingness to develop common law considering social/political factors, which can lead to major changes but may be seen as overstepping.</li>
-                                        <li><strong>Costs and Time:</strong> Litigation can be expensive and lengthy, deterring individuals and limiting cases that come before courts.</li>
-                                        <li><strong>Requirement for Standing (Locus Standi):</strong> Parties must have a 'special interest' and be directly affected by an issue to bring a case [cite: 35-36, 261, 462, 889]. This prevents frivolous cases but can also stop public interest matters from being heard.</li>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li><strong>Definition:</strong> A rule where judges must follow the legal reasoning ('ratio decidendi') of decisions made by higher courts in the same court hierarchy when deciding cases with similar material facts ('stare decisis' - to stand by what has been decided).</li>
+                                        <li><strong>Court Hierarchy:</strong> Necessary for the doctrine to operate, determining which precedents are binding.</li>
+                                        <li><strong>Binding Precedent:</strong> The ratio decidendi of a higher court that <em>must</em> be followed by lower courts in the same hierarchy when material facts are similar.</li>
+                                        <li><strong>Persuasive Precedent:</strong> Legal reasoning that is not binding but can influence a judge's decision. Can come from courts in other hierarchies, lower courts, courts of the same standing, or obiter dictum.</li>
+                                        <li><strong>Obiter Dictum:</strong> Comments made 'by the way' in a judgment that are not part of the ratio decidendi but can be persuasive precedent.</li>
+                                        <li><strong>Avoiding/Changing Precedent (RODD):</strong>
+                                            <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-500">
+                                                <li><strong>Reversing:</strong> A higher court changes the decision of a lower court in the <em>same case</em> on appeal. The original decision is no longer precedent.</li>
+                                                <li><strong>Overruling:</strong> A higher court changes a precedent set by a lower court (or a court of the same standing) in a <em>different, later case</em>. The old precedent is no longer valid.</li>
+                                                <li><strong>Distinguishing:</strong> A court finds the material facts of the current case are sufficiently different from a case where a binding precedent was set, allowing the court to not follow that precedent.</li>
+                                                <li><strong>Disapproving:</strong> A court expresses disagreement with a precedent from a higher court or a court of the same standing but is still bound to follow it (obiter dictum). This doesn't change the precedent but can highlight the need for reform.</li>
+                                            </ul>
+                                        </li>
+                                    </ul>
+                                    <h5 class="font-semibold text-indigo-600 mt-3 mb-1">Statutory Interpretation</h5>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li><strong>Definition:</strong> The process where courts give meaning to words or phrases in legislation when applying it to a case.</li>
+                                        <li><strong>Reasons:</strong> Needed when words/phrases are ambiguous, undefined, or their meaning has changed over time, or to apply legislation to unforeseen circumstances not considered during drafting.</li>
+                                        <li><strong>Effects:</strong>
+                                            <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-500">
+                                                <li>Creates precedent: The interpretation sets a precedent for how that legislation is applied in future cases.</li>
+                                                <li>Broadens or narrows statutes: The interpretation can expand or restrict the scope and application of the legislation.</li>
+                                                <li>Prompts legislative change: Court decisions interpreting statutes can highlight issues or gaps, prompting Parliament to amend the law.</li>
+                                            </ul>
+                                        </li>
                                     </ul>
                                 </div>
                             </div>
                         </div>
-
-                        <div id="u4aos1-courts-parliament-relationship" class="u4aos1-content hidden">
-                           <div class="border border-slate-300 rounded-lg">
+                        <div id="u4aos1-ks7" class="u4aos1-content hidden">
+                            <div class="border border-slate-300 rounded-lg">
                                 <button class="accordion-toggle w-full text-left p-4 bg-indigo-50 hover:bg-indigo-100 rounded-t-lg">
                                     <div class="flex justify-between items-center">
-                                        <h4 class="text-lg font-medium text-indigo-700">Relationship Between Courts and Parliament in Law-Making</h4>
+                                        <h4 class="text-lg font-medium text-indigo-700">Factors that Affect the Ability of Courts to Make Law</h4>
                                         <span class="arrow-icon text-indigo-700 text-xl transform transition-transform duration-300">▼</span>
                                     </div>
                                 </button>
                                 <div class="accordion-content p-4 border-t border-slate-200">
-                                    <p class="mb-3 text-slate-600">Courts and Parliament have a dynamic and complementary relationship in law-making.</p>
-                                    <ul class="list-disc list-inside ml-4 text-slate-600 text-sm space-y-1">
-                                        <li><strong>Supremacy of Parliament:</strong> Parliament is the supreme law-making body and can make or change any law within its constitutional powers, including overriding common law (except High Court constitutional interpretations).</li>
-                                        <li><strong>Ability of Courts to Influence Parliament:</strong> Judicial decisions, statutory interpretations, and obiter dicta can highlight legal issues or gaps, prompting Parliament to consider law reform.</li>
-                                        <li><strong>Codification of Common Law:</strong> Parliament can enact legislation that incorporates and gives statutory authority to common law principles established by courts (e.g., <em>Mabo case</em> and the Native Title Act 1993 (Cth)).</li>
-                                        <li><strong>Abrogation of Common Law:</strong> Parliament can pass legislation that overrides or cancels common law decisions made by courts (unless the court decision is based on constitutional interpretation by the High Court). E.g., Wrongs (Animals Straying on Highways) Act 1984 (Vic) abrogated the common law position in <em>Trigwell's case</em>.</li>
+                                    <p class="text-sm text-slate-600 mb-2">Several factors influence how effectively courts can make law:</p>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li><strong>The Doctrine of Precedent:</strong> Limits courts as they must wait for a relevant case to be brought before them. Judges are restricted to making comments relevant to the case (ratio decidendi). Finding relevant precedents can be timely and costly. Lower courts must follow binding precedent even if they disagree.</li>
+                                        <li><strong>Judicial Conservatism vs Judicial Activism:</strong>
+                                            <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-500">
+                                                <li><strong>Judicial Conservatism:</strong> Reluctance to make new law, viewing it as Parliament's role. Tend to interpret laws narrowly. Can limit law reform.</li>
+                                                <li><strong>Judicial Activism:</strong> Willingness to develop common law and consider social/political factors. May interpret laws more broadly. Can lead to significant legal changes (e.g., Mabo). Can be seen as undemocratic or lead to uncertainty.</li>
+                                            </ul>
+                                        </li>
+                                        <li><strong>Costs and Time in Bringing a Case to Court:</strong>
+                                            <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-500">
+                                                <li><strong>Costs:</strong> Legal representation, court fees, jury fees can be very high, particularly in higher courts. This can deter individuals from pursuing cases, limiting the opportunities for courts to make law. VLA support is limited.</li>
+                                                <li><strong>Time:</strong> Cases can take months or years due to preparation, lengthy trials, and backlogs. Delays can deter litigants.</li>
+                                            </ul>
+                                        </li>
+                                        <li><strong>The Requirement for Standing:</strong> A party must be directly affected by the issue or have a 'special interest' to bring a case.
+                                            <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-500">
+                                                <li><strong>Effect:</strong> Ensures cases are brought by genuinely affected parties but can prevent public interest cases where no single person is uniquely impacted. Limits who can initiate action, potentially meaning important issues aren't challenged.</li>
+                                            </ul>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="u4aos1-ks8" class="u4aos1-content hidden">
+                            <div class="border border-slate-300 rounded-lg">
+                                <button class="accordion-toggle w-full text-left p-4 bg-indigo-50 hover:bg-indigo-100 rounded-t-lg">
+                                    <div class="flex justify-between items-center">
+                                        <h4 class="text-lg font-medium text-indigo-700">The Relationship Between Courts and Parliament in Law-making</h4>
+                                        <span class="arrow-icon text-indigo-700 text-xl transform transition-transform duration-300">▼</span>
+                                    </div>
+                                </button>
+                                <div class="accordion-content p-4 border-t border-slate-200">
+                                    <p class="text-sm text-slate-600 mb-2">Courts and Parliament have a complementary relationship in law-making.</p>
+                                    <ul class="list-disc list-inside ml-4 text-sm space-y-1 text-slate-600">
+                                        <li><strong>Supremacy of Parliament:</strong> Parliament is the supreme law-making body within its jurisdiction. It can make or change any law within its power. Parliament can <strong>abrogate (override)</strong> most common law made by courts. This ensures parliamentary laws reflect community values. Parliament cannot abrogate High Court decisions on constitutional matters.</li>
+                                        <li><strong>Ability of Courts to Influence Parliament:</strong> Court decisions, particularly those highlighting issues with existing law or suggesting reform in obiter dictum, can <strong>influence Parliament</strong> to change the law. Cases can raise public awareness and prompt legislative action.</li>
+                                        <li><strong>Codification of Common Law:</strong> Parliament can <strong>codify (affirm)</strong> common law principles developed by courts by passing legislation that incorporates them. This makes the law more certain and reinforces the common law principle. The <em>Native Title Act 1993 (Cth)</em> codified the High Court's decision in the <em>Mabo Case (No. 2)</em>.</li>
+                                        <li><strong>Abrogation of Common Law:</strong> Parliament can override judge-made law by passing statutes that conflict with it. This is done when Parliament disagrees with a common law decision or believes it is outdated.</li>
                                     </ul>
                                 </div>
                             </div>


### PR DESCRIPTION
This replaces the previous informational accordion sections in Unit 4 Area of Study 1 with 8 new sections based on your supplied Key Skill headings.

Changes include:
- Removed old informational buttons and content divs from `index.html`.
- Added 8 new buttons and corresponding content divs for Key Skills 1-8 (e.g., "1. Roles of the Crown and the Houses of Parliament", "2. The Division of Law-making Powers", etc.).
- Migrated and reformatted descriptive text from the markdown you provided into these new 8 Key Skill sections.
- Existing interactive tools (Glossary, Diagrams, Case Explorer, Key Skills Hub, Guided Answers, Case Deconstructor, Term Match Game, Exam Skills, Practice Questions) remain as top-level toggleable items; their structure and functionality are preserved.
- I verified that `script.js` correctly handles the new structure for showing/hiding content and managing button active states without requiring modification due to its existing robust logic.