### PR TITLE
Add Exam Mastery Hub skeleton

### DIFF
--- a/examData.js
+++ b/examData.js
@@ -1,0 +1,31 @@
+// examData.js - central data structure for Exam Mastery Hub
+// This file defines categories, objectives and question banks for exam practice
+
+export const examData = {
+  unit4: {
+    aos1: {
+      skills: [
+        {
+          id: 'divisionOfPowers',
+          name: 'Division of Powers',
+          objectives: [
+            'Explain exclusive powers',
+            'Distinguish between concurrent and residual powers'
+          ],
+          questions: [
+            {
+              id: 'dop-q1',
+              text: 'Which section of the Constitution lists concurrent powers?',
+              answer: 'Section 51',
+              difficulty: 'easy',
+              topic: 'Constitution',
+              skillType: 'recall',
+              marks: 1,
+              time: 1
+            }
+          ]
+        }
+      ]
+    }
+  }
+};

--- a/examMasteryHub.js
+++ b/examMasteryHub.js
@@ -1,0 +1,35 @@
+// examMasteryHub.js - handles rendering and progress tracking for Exam Mastery Hub
+import { examData } from './examData.js';
+
+const STORAGE_KEY = 'examHubProgress';
+
+function getStoredProgress() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw ? JSON.parse(raw) : {};
+}
+
+function saveProgress(progress) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+}
+
+export function recordQuestionResult(questionId, correct) {
+  const progress = getStoredProgress();
+  progress[questionId] = { correct, timestamp: Date.now() };
+  saveProgress(progress);
+}
+
+export function getProgress() {
+  return getStoredProgress();
+}
+
+// Simple renderer placeholder
+export function renderExamHub(containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  container.innerHTML = '<p class="text-slate-600">Exam Mastery Hub coming soon.</p>';
+}
+
+// Initialize on DOMContentLoaded
+document.addEventListener('DOMContentLoaded', () => {
+  renderExamHub('exam-mastery-hub');
+});

--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
         <nav id="mainNav" class="mb-8 flex justify-center space-x-2 sm:space-x-4 border-b pb-4">
             <button data-target="unit3-content" class="nav-button main-nav-button bg-slate-200 text-slate-700 hover:bg-indigo-500 hover:text-white focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-50 font-medium py-2 px-4 sm:py-3 sm:px-6 rounded-lg transition-colors duration-150">Unit 3: Rights and Justice</button>
             <button data-target="unit4-content" class="nav-button main-nav-button bg-slate-200 text-slate-700 hover:bg-indigo-500 hover:text-white focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-50 font-medium py-2 px-4 sm:py-3 sm:px-6 rounded-lg transition-colors duration-150">Unit 4: The People, the Law and Reform</button>
+            <button data-target="exam-mastery-hub-content" class="nav-button main-nav-button bg-slate-200 text-slate-700 hover:bg-indigo-500 hover:text-white focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-50 font-medium py-2 px-4 sm:py-3 sm:px-6 rounded-lg transition-colors duration-150">Exam Mastery Hub</button>
         </nav>
 
         <main>
@@ -2035,7 +2036,13 @@
                     </div>
                     <p class="mt-8 p-4 bg-sky-100 text-sky-700 rounded-md text-sm">This section will be further developed with detailed explanations, case studies, interactive diagrams, and practice questions for Unit 4, Area of Study 2.</p>
                 </section>
-            </section> </main>
+            </section>
+
+            <section id="exam-mastery-hub-content" class="main-content-section bg-white p-6 rounded-xl shadow-lg">
+                <h2 class="text-2xl font-semibold text-indigo-700 mb-4 text-center">Exam Mastery Hub</h2>
+                <div id="exam-mastery-hub"></div>
+            </section>
+        </main>
 
         <footer class="mt-12 pt-8 border-t border-slate-300 text-center text-sm text-slate-500">
             <p>&copy; <span id="currentYear"></span> Interactive Legal Studies Hub. For educational purposes.</p>
@@ -2045,5 +2052,7 @@
     <script src="script.js"></script>
     <script src="keySkillsHub.js"></script>
     <script src="caseReconstructionDOP.js"></script>
+    <script type="module" src="examData.js"></script>
+    <script type="module" src="examMasteryHub.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add an Exam Mastery Hub navigation button and placeholder section
- add examData.js with initial question data structure
- implement examMasteryHub.js for progress tracking and placeholder rendering

## Testing
- `node -e "import('./examData.js').then(m=>console.log('keys',Object.keys(m.examData)))"`
- `node -e "import('./examMasteryHub.js').then(()=>console.log('ok'))` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684cd1094954832c8b527bc62a5308be